### PR TITLE
Add `prettydoc` to `Suggests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,8 +46,9 @@ Imports: shiny,
     GenomicDataCommons,
     BiocParallel
 Suggests: knitr,
-    testthat,
-	rmarkdown
+    prettydoc,
+    rmarkdown,
+    testthat
 VignetteBuilder: knitr
 biocViews: ImmunoOncology, GeneExpression, DifferentialExpression, GeneRegulation, GeneTarget, 
 	NetworkInference, Survival, Visualization, GeneSetEnrichment,


### PR DESCRIPTION
Solves the following `R CMD check` [error](https://bioconductor.org/checkResults/3.18/bioc-LATEST/GDCRNATools/kunpeng2-checksrc.html) in Bioc 3.18:
```
* checking re-building of vignette outputs ... ERROR
Error(s) in re-building vignettes:
  ...
--- re-building ‘index.Rmd’ using rmarkdown
Error: processing vignette 'index.Rmd' failed with diagnostics:
there is no package called ‘prettydoc’
--- failed re-building ‘index.Rmd’
```

It seems `prettydoc` is a transitive dependency that must be explicitly declared for Bioc 3.18, because of _R_CHECK_SUGGESTS_ONLY_=true

See https://support.bioconductor.org/p/9153573/#9153581 for more details.
